### PR TITLE
Fix deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ class BodyOption {
           body: {
             usage: 'The HTTP body data in the event, format: Json string or json file path.',
             shortcut: 'b',
+            type: 'string',
           },
         },
 
@@ -29,6 +30,7 @@ class BodyOption {
               body: {
                 usage: 'The HTTP body data in the event, format: Json string or json file path.',
                 shortcut: 'b',
+                type: 'string',
               },
             },
           },


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
 - BodyOption for "body"
```